### PR TITLE
Return the results of readdir

### DIFF
--- a/dropbox.js
+++ b/dropbox.js
@@ -286,7 +286,7 @@ angular.module('dropbox', [])
               });
               
               console.log('readdir of ' + path, entries);
-              deferred.resolve(); 
+              deferred.resolve(entries); 
             }
 
             function failure(fault) { deferred.reject(fault); }


### PR DESCRIPTION
deffered.resolve was returning nothing so there was no way to get the results of the readdir method. It was logging but not returning the list of files.
