### PR TITLE
adds support for requesting binary responseTypes

### DIFF
--- a/dropbox.js
+++ b/dropbox.js
@@ -120,7 +120,21 @@ angular.module('dropbox', [])
          */
 
         function GET(url, params) {
+          var responseType = 'text';
+          if (params) {
+            if (params.arrayBuffer) {
+              responseType = 'arraybuffer';
+            } else if (params.blob) {
+              responseType = 'blob';
+            } else if (params.buffer) {
+              responseType = 'buffer';
+            } else if (params.binary) {
+              responseType = 'b'; // See the Dropbox.Util.Xhr.setResponseType docs
+            }
+          }
+
           return request({
+            responseType: responseType,
             method: 'GET',
             url: url,
             params: params

--- a/test/spec/DropboxSpec.coffee
+++ b/test/spec/DropboxSpec.coffee
@@ -71,6 +71,11 @@ describe 'Dropbox', ->
       Dropbox.readFile 'directory/name.ext'
       $httpBackend.flush()
 
+    it 'should get the contents of a file as a blob', ->
+      url = "#{Dropbox.urls.getFile}directory/name.ext?blob=true"
+      $httpBackend.expectGET(url, headers).respond null
+      Dropbox.readFile 'directory/name.ext', 'blob' : true
+      $httpBackend.flush()
 
   describe 'writeFile', ->
 


### PR DESCRIPTION
adds responseType option to request in GET (I needed 'blob' type, but following dropbox-js example), allowing dropbox api to return arrayBuffer, blob, buffer and binary responses.
also adds a test for 'blob' type
