### PR TITLE
git url format that works on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This module is extracted from an AngularJS application. It mostly satisfies the 
 
 [Bower](http://bower.io/) is the quickest way to include ngDropbox in your project.
 
-    $ bower install git@github.com:christiansmith/ngDropbox.git --save
+    $ bower install git://github.com/christiansmith/ngDropbox.git --save
 
     <script src="bower_components/ngDropbox/dropbox.js"></script>
 


### PR DESCRIPTION
the bower command you had didn't work (win 7), changing the url as I did makes it work
